### PR TITLE
Phase 3: tracked-resource cleanup + HTTP timeouts

### DIFF
--- a/quiet_riot/core/enumeration/resource_manager.py
+++ b/quiet_riot/core/enumeration/resource_manager.py
@@ -4,6 +4,7 @@ Resource manager for AWS resources created during scanning.
 Ensures proper cleanup of all created resources.
 """
 
+import contextlib
 import logging
 
 logger = logging.getLogger(__name__)
@@ -90,91 +91,68 @@ class ResourceManager:
         return success
 
     def _cleanup_s3_bucket(self) -> bool:
-        """Clean up S3 bucket."""
+        """Delete only the bucket this manager created (paginated empty first)."""
+        if not self.s3_bucket:
+            return True
+        s3 = self.session.client("s3")
         try:
-            s3 = self.session.client("s3")
-            buckets = s3.list_buckets()
-
-            for bucket in buckets.get("Buckets", []):
-                if "quiet-riot-bucket" in bucket["Name"]:
-                    try:
-                        # Empty bucket first (required for deletion)
-                        bucket_name = bucket["Name"]
-                        try:
-                            objects = s3.list_objects_v2(Bucket=bucket_name)
-                            if "Contents" in objects:
-                                for obj in objects["Contents"]:
-                                    s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
-                        except Exception as e:
-                            logger.debug(f"Error listing/emptying bucket {bucket_name}: {e}")
-
-                        s3.delete_bucket(Bucket=bucket_name)
-                        logger.info(f"Deleted S3 bucket: {bucket_name}")
-                        return True
-                    except Exception as e:
-                        logger.warning(f"Error deleting S3 bucket {bucket['Name']}: {e}")
-                        return False
+            paginator = s3.get_paginator("list_objects_v2")
+            for page in paginator.paginate(Bucket=self.s3_bucket):
+                objects = [{"Key": o["Key"]} for o in page.get("Contents", [])]
+                if objects:
+                    s3.delete_objects(Bucket=self.s3_bucket, Delete={"Objects": objects})
+            s3.delete_bucket(Bucket=self.s3_bucket)
+            logger.info(f"Deleted S3 bucket: {self.s3_bucket}")
+            return True
+        except s3.exceptions.NoSuchBucket:
+            logger.debug(f"S3 bucket already gone: {self.s3_bucket}")
             return True
         except Exception as e:
-            logger.error(f"Error during S3 bucket cleanup: {e}")
+            logger.warning(f"Error deleting S3 bucket {self.s3_bucket}: {e}")
             return False
 
     def _cleanup_ecr_public_repo(self) -> bool:
-        """Clean up ECR Public repository."""
+        """Delete only the ECR Public repository this manager created."""
+        if not self.ecr_public_repo:
+            return True
+        ecr = self.session.client("ecr-public")
         try:
-            ecr_public = self.session.client("ecr-public")
-            repos = ecr_public.describe_repositories()
-
-            for repo in repos.get("repositories", []):
-                if "quiet-riot-public-repo" in repo["repositoryName"]:
-                    try:
-                        ecr_public.delete_repository(repositoryName=repo["repositoryName"])
-                        logger.info(f"Deleted ECR Public repository: {repo['repositoryName']}")
-                        return True
-                    except Exception as e:
-                        logger.warning(f"Error deleting ECR Public repo {repo['repositoryName']}: {e}")
-                        return False
+            ecr.delete_repository(repositoryName=self.ecr_public_repo, force=True)
+            logger.info(f"Deleted ECR Public repository: {self.ecr_public_repo}")
+            return True
+        except ecr.exceptions.RepositoryNotFoundException:
             return True
         except Exception as e:
-            logger.error(f"Error during ECR Public cleanup: {e}")
+            logger.warning(f"Error deleting ECR Public repo {self.ecr_public_repo}: {e}")
             return False
 
     def _cleanup_ecr_private_repo(self) -> bool:
-        """Clean up ECR Private repository."""
+        """Delete only the ECR Private repo this manager created (+ its registry policy)."""
+        if not self.ecr_private_repo:
+            return True
+        ecr = self.session.client("ecr")
+        # The scan sets an account-level registry policy; remove it best-effort.
+        with contextlib.suppress(Exception):
+            ecr.delete_registry_policy()
         try:
-            ecr_private = self.session.client("ecr")
-            repos = ecr_private.describe_repositories()
-
-            for repo in repos.get("repositories", []):
-                if "quiet-riot-private-repo" in repo["repositoryName"]:
-                    try:
-                        ecr_private.delete_repository(repositoryName=repo["repositoryName"])
-                        logger.info(f"Deleted ECR Private repository: {repo['repositoryName']}")
-                        return True
-                    except Exception as e:
-                        logger.warning(f"Error deleting ECR Private repo {repo['repositoryName']}: {e}")
-                        return False
+            ecr.delete_repository(repositoryName=self.ecr_private_repo, force=True)
+            logger.info(f"Deleted ECR Private repository: {self.ecr_private_repo}")
+            return True
+        except ecr.exceptions.RepositoryNotFoundException:
             return True
         except Exception as e:
-            logger.error(f"Error during ECR Private cleanup: {e}")
+            logger.warning(f"Error deleting ECR Private repo {self.ecr_private_repo}: {e}")
             return False
 
     def _cleanup_sns_topic(self) -> bool:
-        """Clean up SNS topic."""
+        """Delete only the SNS topic this manager created (delete_topic is idempotent)."""
+        if not self.sns_topic_arn:
+            return True
+        sns = self.session.client("sns")
         try:
-            sns = self.session.client("sns")
-            topics = sns.list_topics()
-
-            for topic in topics.get("Topics", []):
-                if "quiet-riot-sns-topic" in topic["TopicArn"]:
-                    try:
-                        sns.delete_topic(TopicArn=topic["TopicArn"])
-                        logger.info(f"Deleted SNS topic: {topic['TopicArn']}")
-                        return True
-                    except Exception as e:
-                        logger.warning(f"Error deleting SNS topic {topic['TopicArn']}: {e}")
-                        return False
+            sns.delete_topic(TopicArn=self.sns_topic_arn)
+            logger.info(f"Deleted SNS topic: {self.sns_topic_arn}")
             return True
         except Exception as e:
-            logger.error(f"Error during SNS topic cleanup: {e}")
+            logger.warning(f"Error deleting SNS topic {self.sns_topic_arn}: {e}")
             return False

--- a/quiet_riot/core/enumeration_handlers.py
+++ b/quiet_riot/core/enumeration_handlers.py
@@ -13,6 +13,9 @@ from .enumeration import loadbalancer, s3aclenum
 
 logger = logging.getLogger(__name__)
 
+# Bound every outbound HTTP request so a hung endpoint can't stall a scan.
+HTTP_TIMEOUT = float(os.getenv("QUIET_RIOT_HTTP_TIMEOUT", "15"))
+
 
 class EnumerationHandler:
     """Handles enumeration for different scan types."""
@@ -168,7 +171,7 @@ class EnumerationHandler:
 
         url = f"https://login.microsoftonline.com/getuserrealm.srf?login=user@{domain_name}"
         try:
-            response = requests.get(url)  # nosec B113
+            response = requests.get(url, timeout=HTTP_TIMEOUT)  # nosec B113
             response_text = response.text
 
             valid_managed = re.search('"NameSpaceType":"Managed",', response_text)
@@ -221,7 +224,7 @@ class EnumerationHandler:
 
         try:
             body = f'{{"Username":"{email}"}}'
-            response = requests.post(self.ms_url, data=body)  # nosec B113
+            response = requests.post(self.ms_url, data=body, timeout=HTTP_TIMEOUT)  # nosec B113
             response_text = response.text
 
             valid_response = re.search('"IfExistsResult":0,', response_text)
@@ -270,7 +273,7 @@ class EnumerationHandler:
 
         try:
             params = {"email": email}
-            response = requests.get("https://mail.google.com/mail/gxlu", params=params)  # nosec B113
+            response = requests.get("https://mail.google.com/mail/gxlu", params=params, timeout=HTTP_TIMEOUT)  # nosec B113
             response_cookies = response.cookies
 
             if len(response_cookies) == 1:

--- a/tests/unit/test_resource_manager.py
+++ b/tests/unit/test_resource_manager.py
@@ -60,3 +60,23 @@ def test_cleanup_removes_s3_sns_ecr_private(moto_session):
 def test_cleanup_noop_when_nothing_created(moto_session):
     rm = ResourceManager(moto_session)
     assert rm.cleanup_all(force=True) is True
+
+
+def test_cleanup_only_deletes_tracked_resource_not_bystanders(moto_session):
+    """Regression: cleanup must delete ONLY this manager's bucket.
+
+    Previously it listed every ``quiet-riot-bucket*`` and deleted matches, so a
+    concurrent scan's bucket would be destroyed. A bystander bucket must survive.
+    """
+    s3 = moto_session.client("s3")
+    s3.create_bucket(Bucket="quiet-riot-bucket-mine")
+    s3.create_bucket(Bucket="quiet-riot-bucket-other-scan")  # a concurrent scan's bucket
+
+    rm = ResourceManager(moto_session)
+    rm.s3_bucket = "quiet-riot-bucket-mine"
+    rm.resources_created = True
+    rm.cleanup_all(force=True)
+
+    remaining = {b["Name"] for b in s3.list_buckets().get("Buckets", [])}
+    assert "quiet-riot-bucket-mine" not in remaining
+    assert "quiet-riot-bucket-other-scan" in remaining, "bystander scan's bucket must not be deleted"


### PR DESCRIPTION
Second overhaul PR (Phase 3 — engine safety). Builds on the Phase 0 foundation now on `main`.

## Resource cleanup no longer cross-deletes concurrent scans
`ResourceManager.cleanup_all` previously listed **every** `quiet-riot-*` bucket/repo/topic and deleted the first match — so two scans running at once would destroy each other's resources, and multiple leftovers were only partially cleaned. It now deletes **only the specific resources this manager created** (`self.s3_bucket`, `self.ecr_public_repo`, …). Also:
- S3 emptying is paginated (`list_objects_v2` paginator + `delete_objects`) so buckets with >1000 objects actually empty before deletion.
- ECR deletes use `force=True` and treat `RepositoryNotFoundException` / `NoSuchBucket` as success (idempotent).
- The account-level ECR registry policy the scan sets is removed on cleanup.
- New test `test_cleanup_only_deletes_tracked_resource_not_bystanders` proves a concurrent scan's bucket survives.

## HTTP timeouts on the SaaS paths
M365 domain/user and Google Workspace probes used `requests` with **no timeout** — a hung endpoint could stall a scan indefinitely. All three now use `timeout=HTTP_TIMEOUT` (`QUIET_RIOT_HTTP_TIMEOUT`, default 15s).

## Verification
`ruff`/`mypy` clean; **60 unit + 9 live** tests green; confirmed zero leaked AWS resources after a live run. CI (incl. the live-AWS OIDC job) gates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)