### PR TITLE
Phase 2: web-layer hardening (non-blocking scans, auth, localhost bind)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "moto[ecr,sns,s3,sts]>=5.0.0",
     "types-requests>=2.28.0",
     "httpx>=0.24.0",
+    "pytest-timeout>=2.1.0",
     "pre-commit>=3.0.0",
 ]
 
@@ -147,6 +148,10 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --cov=quiet_riot --cov-report=html --cov-report=term-missing"
+# Backstop so a hung live test (e.g. a stalled AWS/SaaS socket) fails fast with a
+# traceback instead of stalling CI for the whole job timeout.
+timeout = 180
+timeout_method = "thread"
 
 [tool.coverage.run]
 source = ["quiet_riot"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "mypy>=1.5.0",
     "moto[ecr,sns,s3,sts]>=5.0.0",
     "types-requests>=2.28.0",
+    "httpx>=0.24.0",
     "pre-commit>=3.0.0",
 ]
 

--- a/quiet_riot/api/server.py
+++ b/quiet_riot/api/server.py
@@ -3,12 +3,17 @@
 FastAPI server for Quiet Riot with dashboard UI.
 """
 
+import asyncio
 from contextlib import asynccontextmanager
+from datetime import datetime
 import logging
+import os
 from pathlib import Path
+import secrets
+import uuid
 
 import boto3
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -28,6 +33,24 @@ credentials_required: bool = False
 # Track infrastructure resources across all scans
 infrastructure_resources: dict[str, dict] = {}
 
+# Optional bearer-token auth: if QUIET_RIOT_API_TOKEN is set, sensitive
+# endpoints require "Authorization: Bearer <token>". If unset, auth is disabled
+# (warned at startup) and the server should be bound to localhost only.
+API_TOKEN = os.getenv("QUIET_RIOT_API_TOKEN")
+# Hard cap on emails returned by /api/generate-emails to prevent OOM.
+MAX_EMAIL_RESPONSE = int(os.getenv("QUIET_RIOT_MAX_EMAILS", "50000"))
+# Hold references to fire-and-forget scan tasks so they aren't garbage-collected.
+_scan_tasks: set[asyncio.Task] = set()
+
+
+def require_token(authorization: str | None = Header(default=None)) -> None:
+    """Gate sensitive endpoints behind a bearer token when one is configured."""
+    if not API_TOKEN:
+        return
+    expected = f"Bearer {API_TOKEN}"
+    if not authorization or not secrets.compare_digest(authorization, expected):
+        raise HTTPException(status_code=401, detail="Missing or invalid API token")
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -35,6 +58,12 @@ async def lifespan(app: FastAPI):
     global scanner, credentials_required, current_profile
     # Startup
     logger.info("Initializing Quiet Riot API server...")
+
+    if not API_TOKEN:
+        logger.warning(
+            "QUIET_RIOT_API_TOKEN is not set - API authentication is DISABLED. "
+            "Keep the server bound to localhost (default) or set a token before exposing it."
+        )
 
     credentials_mgr = get_credentials_manager()
 
@@ -183,7 +212,7 @@ async def get_scan_types():
     }
 
 
-@app.post("/api/credentials")
+@app.post("/api/credentials", dependencies=[Depends(require_token)])
 async def set_credentials(credentials_request: CredentialsRequest):
     """Set AWS credentials for the API server."""
     global scanner, current_profile, credentials_required
@@ -228,7 +257,7 @@ async def set_credentials(credentials_request: CredentialsRequest):
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.get("/api/credentials")
+@app.get("/api/credentials", dependencies=[Depends(require_token)])
 async def get_credentials_status():
     """Get current AWS credentials status."""
     global scanner, current_profile, credentials_required
@@ -251,7 +280,7 @@ async def get_credentials_status():
     }
 
 
-@app.post("/api/scans")
+@app.post("/api/scans", status_code=202, dependencies=[Depends(require_token)])
 async def start_scan(scan_request: ScanRequest):
     """Start a new scan."""
     global scanner, current_profile
@@ -379,31 +408,50 @@ async def start_scan(scan_request: ScanRequest):
             timeout=scan_request.timeout if hasattr(scan_request, "timeout") else None,
         )
 
-        # Run scan (synchronous for now - can be made async later)
-        # In production, this should run in a background task
-        # Don't cleanup immediately - let user manage cleanup via UI
-        result = scan_scanner.run_scan(scan_config, cleanup=False)
-        active_scans[result.scan_id] = result
+        # Run the (blocking, multi-threaded) scan off the event loop in a worker
+        # thread so the server stays responsive. Return a job id immediately and
+        # let the client poll GET /api/scans/{scan_id}.
+        job_id = str(uuid.uuid4())
+        active_scans[job_id] = ScanResult(
+            scan_id=job_id,
+            scan_type=scan_type,
+            status="running",
+            valid_principals=[],
+            total_scanned=0,
+            start_time=datetime.now(),
+        )
 
-        # Track infrastructure resources created for this scan
-        if scan_scanner.resource_mgr.resources_created:
-            infrastructure_resources[result.scan_id] = {
-                "ecr_public_repo": scan_scanner.resource_mgr.ecr_public_repo,
-                "ecr_private_repo": scan_scanner.resource_mgr.ecr_private_repo,
-                "sns_topic_arn": scan_scanner.resource_mgr.sns_topic_arn,
-                "s3_bucket": scan_scanner.resource_mgr.s3_bucket,
-                "canonical_id": scan_scanner.resource_mgr.canonical_id,
-                "scan_id": result.scan_id,
-                "scan_type": result.scan_type.value,
-                "created_at": result.start_time.isoformat(),
-            }
+        async def _execute() -> None:
+            try:
+                result = await asyncio.to_thread(scan_scanner.run_scan, scan_config, False)
+                result.scan_id = job_id
+                active_scans[job_id] = result
+                if scan_scanner.resource_mgr.resources_created:
+                    infrastructure_resources[job_id] = {
+                        "ecr_public_repo": scan_scanner.resource_mgr.ecr_public_repo,
+                        "ecr_private_repo": scan_scanner.resource_mgr.ecr_private_repo,
+                        "sns_topic_arn": scan_scanner.resource_mgr.sns_topic_arn,
+                        "s3_bucket": scan_scanner.resource_mgr.s3_bucket,
+                        "canonical_id": scan_scanner.resource_mgr.canonical_id,
+                        "scan_id": job_id,
+                        "scan_type": result.scan_type.value,
+                        "created_at": result.start_time.isoformat(),
+                    }
+            except Exception as exc:
+                logger.exception(f"Scan {job_id} failed: {exc}")
+                failed = active_scans[job_id]
+                failed.status = "failed"
+                failed.error = str(exc)
+                failed.end_time = datetime.now()
+
+        task = asyncio.create_task(_execute())
+        _scan_tasks.add(task)
+        task.add_done_callback(_scan_tasks.discard)
 
         return {
-            "scan_id": result.scan_id,
-            "status": result.status,
-            "message": ("Scan completed successfully" if result.status == "completed" else "Scan failed"),
-            "valid_principals_count": len(result.valid_principals),
-            "total_scanned": result.total_scanned,
+            "scan_id": job_id,
+            "status": "running",
+            "message": "Scan started; poll GET /api/scans/{scan_id} for status.",
         }
     except ValueError as e:
         logger.warning(f"Invalid scan request: {e}")
@@ -413,7 +461,7 @@ async def start_scan(scan_request: ScanRequest):
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@app.get("/api/scans/{scan_id}")
+@app.get("/api/scans/{scan_id}", dependencies=[Depends(require_token)])
 async def get_scan_status(scan_id: str):
     """Get status of a scan."""
     if scan_id not in active_scans:
@@ -434,7 +482,7 @@ async def get_scan_status(scan_id: str):
     }
 
 
-@app.get("/api/scans")
+@app.get("/api/scans", dependencies=[Depends(require_token)])
 async def list_scans():
     """List all scans."""
     return {
@@ -450,7 +498,7 @@ async def list_scans():
     }
 
 
-@app.get("/api/generate-emails")
+@app.get("/api/generate-emails", dependencies=[Depends(require_token)])
 async def generate_emails(
     domain: str,
     pattern: str,
@@ -467,8 +515,8 @@ async def generate_emails(
     Returns:
         List of generated email addresses
     """
-    # Limit max emails to 20 million
-    max_emails = min(max_emails, 20_000_000)
+    # Cap the response so we never build/return a multi-million-item list (OOM).
+    max_emails = max(0, min(max_emails, MAX_EMAIL_RESPONSE))
 
     # Wordlists are in the project root
     # Path: quiet_riot/api/server.py -> quiet_riot/ -> project root
@@ -545,7 +593,7 @@ async def generate_emails(
     }
 
 
-@app.get("/api/infrastructure")
+@app.get("/api/infrastructure", dependencies=[Depends(require_token)])
 async def get_infrastructure():
     """Get current AWS infrastructure resources."""
     global scanner, infrastructure_resources
@@ -678,7 +726,7 @@ async def get_infrastructure():
     }
 
 
-@app.post("/api/infrastructure/cleanup")
+@app.post("/api/infrastructure/cleanup", dependencies=[Depends(require_token)])
 async def cleanup_infrastructure():
     """Clean up all AWS infrastructure resources."""
     global scanner, infrastructure_resources
@@ -799,8 +847,13 @@ def main():
     import uvicorn
 
     cfg = config.get_config()
-    logger.info("Starting Quiet Riot FastAPI server...")
-    uvicorn.run(app, host="0.0.0.0", port=8000, log_level=cfg.log_level.lower())  # nosec B104
+    # Default to localhost. Set QUIET_RIOT_HOST=0.0.0.0 to expose the server, but
+    # only do so behind QUIET_RIOT_API_TOKEN (this is an unauthenticated-recon
+    # tool that provisions AWS resources).
+    host = os.getenv("QUIET_RIOT_HOST", "127.0.0.1")
+    port = int(os.getenv("QUIET_RIOT_PORT", "8000"))
+    logger.info(f"Starting Quiet Riot FastAPI server on {host}:{port}...")
+    uvicorn.run(app, host=host, port=port, log_level=cfg.log_level.lower())
 
 
 if __name__ == "__main__":

--- a/quiet_riot/core/enumeration/retry_handler.py
+++ b/quiet_riot/core/enumeration/retry_handler.py
@@ -6,6 +6,7 @@ Handles throttling and transient errors appropriately.
 
 from functools import wraps
 import logging
+import os
 import time
 
 from botocore.config import Config
@@ -74,10 +75,14 @@ def get_botocore_retry_config(max_attempts=7):
         Config: Botocore configuration object
     """
     return Config(
+        # Bound each call so a stalled socket fails fast instead of hanging on the
+        # 60s botocore default (which, multiplied by retries, can stall for minutes).
+        connect_timeout=int(os.getenv("QUIET_RIOT_AWS_CONNECT_TIMEOUT", "10")),
+        read_timeout=int(os.getenv("QUIET_RIOT_AWS_READ_TIMEOUT", "30")),
         retries={
             "max_attempts": max_attempts,
             "mode": "adaptive",  # Adaptive retry mode handles throttling better
-        }
+        },
     )
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,81 @@
+"""Unit tests for the FastAPI app: auth gating, non-blocking scans, email cap.
+
+Uses Starlette's TestClient (no real AWS; the global scanner is mocked).
+"""
+
+from datetime import datetime
+from unittest import mock
+
+from fastapi.testclient import TestClient
+import pytest
+
+from quiet_riot.api import server
+from quiet_riot.core.models import ScanResult, ScanType
+
+
+@pytest.fixture
+def client():
+    with TestClient(server.app) as c:
+        yield c
+    server.active_scans.clear()
+    server.infrastructure_resources.clear()
+
+
+def test_health_is_open(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "healthy"
+
+
+def test_scan_types_is_open(client):
+    r = client.get("/api/scan-types")
+    assert r.status_code == 200
+    assert len(r.json()["scan_types"]) == 7
+
+
+def test_generate_emails_is_capped(client, monkeypatch):
+    monkeypatch.setattr(server, "API_TOKEN", None)
+    monkeypatch.setattr(server, "MAX_EMAIL_RESPONSE", 10)
+    r = client.get(
+        "/api/generate-emails",
+        params={"domain": "x.com", "pattern": "firstname.lastname", "max_emails": 5_000_000},
+    )
+    assert r.status_code == 200
+    assert r.json()["count"] <= 10
+
+
+def test_auth_enforced_when_token_set(client, monkeypatch):
+    monkeypatch.setattr(server, "API_TOKEN", "s3cret")
+    assert client.get("/api/scans").status_code == 401
+    assert client.get("/api/scans", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    assert client.get("/api/scans", headers={"Authorization": "Bearer s3cret"}).status_code == 200
+    # Open endpoints stay open regardless of token.
+    assert client.get("/health").status_code == 200
+
+
+def test_auth_disabled_by_default(client, monkeypatch):
+    monkeypatch.setattr(server, "API_TOKEN", None)
+    assert client.get("/api/scans").status_code == 200
+
+
+def test_start_scan_returns_202_running_immediately(client, monkeypatch):
+    monkeypatch.setattr(server, "API_TOKEN", None)
+    monkeypatch.setattr(server, "credentials_required", False)
+    fake = mock.Mock()
+    fake.run_scan.return_value = ScanResult(
+        scan_id="internal",
+        scan_type=ScanType.MICROSOFT_365_DOMAINS,
+        status="completed",
+        valid_principals=[],
+        total_scanned=1,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    fake.resource_mgr.resources_created = False
+    monkeypatch.setattr(server, "scanner", fake)
+
+    r = client.post("/api/scans", json={"scan_type": 2, "domain_name": "example.com"})
+    assert r.status_code == 202
+    body = r.json()
+    assert body["status"] == "running"
+    assert "scan_id" in body


### PR DESCRIPTION
Third overhaul PR (Phase 2 — web layer). Builds on Phase 0 + Phase 3 now on `main`.

## Non-blocking scans (the event-loop bug)
`POST /api/scans` previously called the synchronous, minutes-long, hundreds-of-threads `run_scan()` **directly inside the async handler**, freezing the entire event loop (including `/health`) for the duration. It now:
- returns **202 + a job id** immediately,
- runs the scan via `asyncio.to_thread` (off the loop, in a worker thread),
- updates `running → completed/failed`, polled via `GET /api/scans/{scan_id}`.

## Security
- **Optional bearer-token auth**: sensitive `/api/*` endpoints require `Authorization: Bearer <QUIET_RIOT_API_TOKEN>` when that env var is set; disabled by default with a loud startup warning. `/`, `/api/scan-types`, `/health` stay open.
- **Localhost by default**: binds `127.0.0.1` (override with `QUIET_RIOT_HOST`) instead of `0.0.0.0`. This tool mints AWS resources and runs unauthenticated recon — it must not default to all-interfaces.
- **`generate-emails` OOM guard**: response capped at `QUIET_RIOT_MAX_EMAILS` (default 50k) instead of building up to 20,000,000 strings in memory.

## Verification
New `tests/unit/test_api.py` (Starlette `TestClient`) covers: auth required/!required, the 202 `running` response, the email cap, and that `/health` + `/api/scan-types` stay open. **66 unit tests** green; ruff/mypy clean; a real uvicorn server was started and confirmed bound to `127.0.0.1` serving `/health` + `/api/scan-types`.

Deferred (noted for a follow-up): durable scan persistence (SQLite) so job state survives a restart — currently in-memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)