### PR TITLE
Correctness round 2: scan-4 fix, results-file isolation, live role/user proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,9 @@ jobs:
       - name: Verify AWS identity
         run: aws sts get-caller-identity
       - name: Live integration tests (real ECR/SNS/S3 + M365/Google)
+        env:
+          # Known-real accounts for the SaaS detection canaries (masked in logs).
+          QR_TEST_M365_EMAIL: ${{ secrets.QR_TEST_M365_EMAIL }}
+          QR_TEST_M365_DOMAIN: ${{ secrets.QR_TEST_M365_DOMAIN }}
+          QR_TEST_GOOGLE_EMAIL: ${{ secrets.QR_TEST_GOOGLE_EMAIL }}
         run: pytest tests/live --run-live

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ curl http://localhost:8000/api/credentials
 4. **AWS Root User Email** - Enumerate AWS root user email addresses
 5. **AWS IAM Principals** - Enumerate IAM roles/users
 6. **Microsoft 365 Users** - Enumerate M365 user emails
-7. **Google Workspace Users** - Enumerate Google Workspace emails
+7. **Google Workspace Users** - _Deprecated._ Google disabled the `gxlu` endpoint this relied on (it now returns HTTP 204 for every address), so this scan reports no users. Kept for compatibility; logs a warning when run.
 
 ## 📁 Project Structure
 

--- a/quiet_riot/api/server.py
+++ b/quiet_riot/api/server.py
@@ -41,6 +41,10 @@ API_TOKEN = os.getenv("QUIET_RIOT_API_TOKEN")
 MAX_EMAIL_RESPONSE = int(os.getenv("QUIET_RIOT_MAX_EMAILS", "50000"))
 # Hold references to fire-and-forget scan tasks so they aren't garbage-collected.
 _scan_tasks: set[asyncio.Task] = set()
+# Serialize scan execution: constructing a Scanner / running a scan mutates the
+# process-wide Config singleton (account + scan_objects) that the enumerator
+# worker threads read live, so two concurrent scans would corrupt each other.
+_scan_lock = asyncio.Lock()
 
 
 def require_token(authorization: str | None = Header(default=None)) -> None:
@@ -310,13 +314,15 @@ async def start_scan(scan_request: ScanRequest):
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid credentials in scan request: {e}") from e
 
-    # Use scan-specific session if provided, otherwise use global scanner
+    # Determine which AWS session this scan runs under. The Scanner itself is
+    # constructed inside the serialized _execute() below, because constructing it
+    # resets the process-wide Config singleton.
     if scan_session:
-        scan_scanner = Scanner(scan_session)
+        effective_session = scan_session
     elif scanner is None:
         raise HTTPException(status_code=503, detail="Scanner not initialized. Check AWS credentials.")
     else:
-        scan_scanner = scanner
+        effective_session = scanner.session
 
     try:
         scan_type = ScanType(str(scan_request.scan_type))
@@ -421,28 +427,35 @@ async def start_scan(scan_request: ScanRequest):
             start_time=datetime.now(),
         )
 
+        def _do_scan():
+            # Constructing the Scanner (resets Config) + running the scan, both in
+            # one worker thread so the event loop is never blocked.
+            s = Scanner(effective_session)
+            return s, s.run_scan(scan_config, cleanup=False)
+
         async def _execute() -> None:
-            try:
-                result = await asyncio.to_thread(scan_scanner.run_scan, scan_config, False)
-                result.scan_id = job_id
-                active_scans[job_id] = result
-                if scan_scanner.resource_mgr.resources_created:
-                    infrastructure_resources[job_id] = {
-                        "ecr_public_repo": scan_scanner.resource_mgr.ecr_public_repo,
-                        "ecr_private_repo": scan_scanner.resource_mgr.ecr_private_repo,
-                        "sns_topic_arn": scan_scanner.resource_mgr.sns_topic_arn,
-                        "s3_bucket": scan_scanner.resource_mgr.s3_bucket,
-                        "canonical_id": scan_scanner.resource_mgr.canonical_id,
-                        "scan_id": job_id,
-                        "scan_type": result.scan_type.value,
-                        "created_at": result.start_time.isoformat(),
-                    }
-            except Exception as exc:
-                logger.exception(f"Scan {job_id} failed: {exc}")
-                failed = active_scans[job_id]
-                failed.status = "failed"
-                failed.error = str(exc)
-                failed.end_time = datetime.now()
+            async with _scan_lock:  # one scan at a time (shared Config singleton)
+                try:
+                    scan_scanner, result = await asyncio.to_thread(_do_scan)
+                    result.scan_id = job_id
+                    active_scans[job_id] = result
+                    if scan_scanner.resource_mgr.resources_created:
+                        infrastructure_resources[job_id] = {
+                            "ecr_public_repo": scan_scanner.resource_mgr.ecr_public_repo,
+                            "ecr_private_repo": scan_scanner.resource_mgr.ecr_private_repo,
+                            "sns_topic_arn": scan_scanner.resource_mgr.sns_topic_arn,
+                            "s3_bucket": scan_scanner.resource_mgr.s3_bucket,
+                            "canonical_id": scan_scanner.resource_mgr.canonical_id,
+                            "scan_id": job_id,
+                            "scan_type": result.scan_type.value,
+                            "created_at": result.start_time.isoformat(),
+                        }
+                except Exception as exc:
+                    logger.exception(f"Scan {job_id} failed: {exc}")
+                    failed = active_scans[job_id]
+                    failed.status = "failed"
+                    failed.error = str(exc)
+                    failed.end_time = datetime.now()
 
         task = asyncio.create_task(_execute())
         _scan_tasks.add(task)
@@ -735,101 +748,70 @@ async def cleanup_infrastructure():
         raise HTTPException(status_code=503, detail="No scanner initialized")
 
     try:
-        # Clean up resources from the scanner's resource manager
-        success = scanner.resource_mgr.cleanup_all(force=True)
-
-        # Also clean up any orphaned resources by querying AWS directly
         session = scanner.session
         cleaned_count = 0
 
-        # Clean up ECR Public repositories
-        try:
-            ecr_public = session.client("ecr-public")
-            repos = ecr_public.describe_repositories()
-            for repo in repos.get("repositories", []):
-                if "quiet-riot-public-repo" in repo["repositoryName"]:
-                    try:
-                        ecr_public.delete_repository(repositoryName=repo["repositoryName"])
-                        cleaned_count += 1
-                    except Exception as e:
-                        logger.warning(f"Error deleting ECR Public repo {repo['repositoryName']}: {e}")
-        except Exception as e:
-            logger.debug(f"Error checking ECR Public: {e}")
+        # The current scanner's own tracked resources.
+        success = scanner.resource_mgr.cleanup_all(force=True)
 
-        # Clean up ECR Private repositories
-        try:
-            ecr_private = session.client("ecr")
-            repos = ecr_private.describe_repositories()
-            for repo in repos.get("repositories", []):
-                if "quiet-riot-private-repo" in repo["repositoryName"]:
-                    try:
-                        ecr_private.delete_repository(repositoryName=repo["repositoryName"])
-                        cleaned_count += 1
-                    except Exception as e:
-                        logger.warning(f"Error deleting ECR Private repo {repo['repositoryName']}: {e}")
-        except Exception as e:
-            logger.debug(f"Error checking ECR Private: {e}")
+        # Plus the EXACT resources recorded for each tracked scan. We delete by
+        # the names we created — never a substring sweep, which would destroy a
+        # concurrent scan's (or a bystander's) "quiet-riot-*" resources.
+        ecr_public = session.client("ecr-public")
+        ecr_private = session.client("ecr")
+        sns = session.client("sns")
+        s3 = session.client("s3")
 
-        # Clean up SNS topics
-        try:
-            sns = session.client("sns")
-            topics = sns.list_topics()
-            for topic in topics.get("Topics", []):
-                if "quiet-riot-sns-topic" in topic["TopicArn"]:
-                    try:
-                        sns.delete_topic(TopicArn=topic["TopicArn"])
-                        cleaned_count += 1
-                    except Exception as e:
-                        logger.warning(f"Error deleting SNS topic {topic['TopicArn']}: {e}")
-        except Exception as e:
-            logger.debug(f"Error checking SNS: {e}")
+        for resources in list(infrastructure_resources.values()):
+            if resources.get("ecr_public_repo"):
+                try:
+                    ecr_public.delete_repository(repositoryName=resources["ecr_public_repo"], force=True)
+                    cleaned_count += 1
+                except Exception as e:
+                    logger.warning(f"Error deleting ECR Public repo {resources['ecr_public_repo']}: {e}")
+            if resources.get("ecr_private_repo"):
+                try:
+                    ecr_private.delete_repository(repositoryName=resources["ecr_private_repo"], force=True)
+                    cleaned_count += 1
+                except Exception as e:
+                    logger.warning(f"Error deleting ECR Private repo {resources['ecr_private_repo']}: {e}")
+            if resources.get("sns_topic_arn"):
+                try:
+                    sns.delete_topic(TopicArn=resources["sns_topic_arn"])
+                    cleaned_count += 1
+                except Exception as e:
+                    logger.warning(f"Error deleting SNS topic {resources['sns_topic_arn']}: {e}")
+            if resources.get("s3_bucket"):
+                bucket = resources["s3_bucket"]
+                try:
+                    paginator = s3.get_paginator("list_objects_v2")
+                    for page in paginator.paginate(Bucket=bucket):
+                        objs = [{"Key": o["Key"]} for o in page.get("Contents", [])]
+                        if objs:
+                            s3.delete_objects(Bucket=bucket, Delete={"Objects": objs})
+                    s3.delete_bucket(Bucket=bucket)
+                    cleaned_count += 1
+                except Exception as e:
+                    logger.warning(f"Error deleting S3 bucket {bucket}: {e}")
 
-        # Clean up S3 buckets
+        # Best-effort: remove the account-level ECR registry policy a scan sets.
+        # NOTE: this overwrites a pre-existing customer registry policy if one
+        # existed (the scan already overwrote it). Save/restore is a follow-up.
         try:
-            s3 = session.client("s3")
-            buckets = s3.list_buckets()
-            for bucket in buckets.get("Buckets", []):
-                if "quiet-riot-bucket" in bucket["Name"]:
-                    try:
-                        # Empty bucket first
-                        bucket_name = bucket["Name"]
-                        try:
-                            objects = s3.list_objects_v2(Bucket=bucket_name)
-                            if "Contents" in objects:
-                                for obj in objects["Contents"]:
-                                    s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
-                        except Exception:
-                            pass
-                        s3.delete_bucket(Bucket=bucket_name)
-                        cleaned_count += 1
-                    except Exception as e:
-                        logger.warning(f"Error deleting S3 bucket {bucket['Name']}: {e}")
+            ecr_private.delete_registry_policy()
         except Exception as e:
-            logger.debug(f"Error checking S3: {e}")
+            logger.debug(f"No ECR registry policy to delete (or already gone): {e}")
 
-        # Clear infrastructure tracking
         infrastructure_resources.clear()
 
-        if success and cleaned_count > 0:
-            return {
-                "status": "success",
-                "message": f"All infrastructure resources cleaned up successfully ({cleaned_count} resources removed)",
-                "resources_cleaned": cleaned_count,
-            }
-        elif success:
-            return {
-                "status": "success",
-                "message": "All infrastructure resources cleaned up successfully",
-            }
-        else:
-            return {
-                "status": "partial",
-                "message": f"Some resources may not have been cleaned up ({cleaned_count} resources removed)",
-                "resources_cleaned": cleaned_count,
-            }
+        return {
+            "status": "success" if success else "partial",
+            "message": f"Cleaned up {cleaned_count} tracked resource(s).",
+            "resources_cleaned": cleaned_count,
+        }
     except Exception as e:
         logger.exception(f"Error cleaning up infrastructure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @app.get("/health")

--- a/quiet_riot/api/server.py
+++ b/quiet_riot/api/server.py
@@ -208,9 +208,10 @@ async def get_scan_types():
             {
                 "id": 7,
                 "name": "Google Workspace Users",
-                "description": "Enumerate Google Workspace user emails",
+                "description": "DEPRECATED - Google disabled the gxlu endpoint this relies on; reports no users.",
                 "requires_config": True,
                 "email_based": True,
+                "deprecated": True,
             },
         ]
     }

--- a/quiet_riot/cli/main.py
+++ b/quiet_riot/cli/main.py
@@ -42,7 +42,7 @@ Examples:
   4. AWS Root User E-mail Address
   5. AWS IAM Principals
   6. Microsoft 365 Users (e-mails)
-  7. Google Workspace Users (e-mails)
+  7. Google Workspace Users (e-mails) [DEPRECATED - gxlu disabled by Google]
         """,
     )
 

--- a/quiet_riot/core/backends.py
+++ b/quiet_riot/core/backends.py
@@ -33,15 +33,10 @@ class LocalThreadPoolBackend:
     name = "local"
 
     def run(self, wordlist_path: str, session, threads: int) -> list[str]:
-        results_file = loadbalancer.threader(
+        return loadbalancer.threader(
             loadbalancer.getter(thread=threads, wordlist=wordlist_path),
             session=session,
         )
-        valid: list[str] = []
-        if results_file and os.path.exists(results_file):
-            with open(results_file) as f:
-                valid = [line.strip() for line in f if line.strip()]
-        return valid
 
 
 class DistributedBackend:

--- a/quiet_riot/core/enumeration/loadbalancer.py
+++ b/quiet_riot/core/enumeration/loadbalancer.py
@@ -4,14 +4,13 @@ import datetime
 import glob
 import logging
 import os
+from pathlib import Path
 import random as rand
-import time
+import uuid
 
 from . import ecrprivenum, ecrpubenum, snsenum
 
 logger = logging.getLogger(__name__)
-
-timestamp = time.strftime("%Y%m%d-%H%M%S")
 
 
 # Function to get a wordlist and ask how many threads, then split the wordlist into sub-wordlists of the appropriate size to generate the number of threads desired (approx) when passed to the threader function
@@ -81,7 +80,7 @@ def balancedchecker(wordlist_chunk, session):
 
 
 # Function to create threads and execute parallel scanning
-def threader(words, session):
+def threader(words, session) -> list[str]:
     """
     Execute parallel scanning using ThreadPoolExecutor for proper thread management.
 
@@ -90,7 +89,7 @@ def threader(words, session):
         session: Boto3 session object
 
     Returns:
-        Path to results file
+        List of validated principals found in this scan.
     """
     logger.info("Identified Valid Principals:")
     ct1 = datetime.datetime.now()
@@ -101,7 +100,7 @@ def threader(words, session):
     total_items = len(length_check)
 
     # Collect all valid results
-    all_valid_results = []
+    all_valid_results: list[str] = []
     threads_used = len(words)
 
     # Use ThreadPoolExecutor for proper thread management and cleanup
@@ -123,9 +122,14 @@ def threader(words, session):
                 logger.error(f"Error processing chunk: {e}")
                 continue
 
-    # Write results to file
-    results_file = f"valid_scan_results-{timestamp}.txt"
-    with open(results_file, "a+") as file:
+    # Write results to a UNIQUE per-scan file (results/ is created by config).
+    # A unique name (not a module-level timestamp) prevents results from one scan
+    # appending into another scan's file, which double-counted IAM-principal hits
+    # and bled results across scans in the long-lived API server.
+    results_dir = Path("results")
+    results_dir.mkdir(exist_ok=True)
+    results_file = results_dir / f"valid_scan_results-{uuid.uuid4().hex}.txt"
+    with open(results_file, "w") as file:
         for principal in all_valid_results:
             file.write(str(principal) + "\n")
 
@@ -152,4 +156,4 @@ def threader(words, session):
         except Exception as f:
             logger.warning(f"Error while deleting file {filePath_two}: {f}")
 
-    return results_file
+    return all_valid_results

--- a/quiet_riot/core/enumeration/resource_manager.py
+++ b/quiet_riot/core/enumeration/resource_manager.py
@@ -43,9 +43,9 @@ class ResourceManager:
         """
         self.ecr_public_repo = ecr_public_repo
         self.ecr_private_repo = ecr_private_repo
-        self.sns_topic_arn = (
-            f"arn:aws:sns:us-east-1:{self.session.client('sts').get_caller_identity()['Account']}:{sns_topic}"
-        )
+        region = self.session.region_name or "us-east-1"
+        account = self.session.client("sts").get_caller_identity()["Account"]
+        self.sns_topic_arn = f"arn:aws:sns:{region}:{account}:{sns_topic}"
         self.s3_bucket = s3_bucket
         self.canonical_id = canonical_id
         self.resources_created = True

--- a/quiet_riot/core/enumeration_handlers.py
+++ b/quiet_riot/core/enumeration_handlers.py
@@ -263,6 +263,19 @@ class EnumerationHandler:
             response = requests.get("https://mail.google.com/mail/gxlu", params=params, timeout=HTTP_TIMEOUT)  # nosec B113
             response_cookies = response.cookies
 
+            # Google DISABLED the gxlu email-existence oracle: it now returns
+            # 204 No Content with no cookies for every address, real or fake
+            # (verified against a known-valid Workspace account). Surface that
+            # clearly instead of silently reporting a (false) negative.
+            if response.status_code == 204 or len(response_cookies) == 0:
+                logger.warning(
+                    "Google Workspace enumeration via the gxlu endpoint is no longer "
+                    "supported by Google (HTTP %s, no cookies) - results are unreliable "
+                    "and will report no valid users. See scan type 7 (deprecated).",
+                    response.status_code,
+                )
+                return [], 1
+
             if len(response_cookies) == 1:
                 logger.info(f"Valid Google Workspace user found: {email}")
                 return [email], 1

--- a/quiet_riot/core/enumeration_handlers.py
+++ b/quiet_riot/core/enumeration_handlers.py
@@ -17,6 +17,10 @@ logger = logging.getLogger(__name__)
 HTTP_TIMEOUT = float(os.getenv("QUIET_RIOT_HTTP_TIMEOUT", "15"))
 
 
+class ThrottlingError(Exception):
+    """Raised when an upstream identity API throttles us mid-scan."""
+
+
 class EnumerationHandler:
     """Handles enumeration for different scan types."""
 
@@ -42,16 +46,9 @@ class EnumerationHandler:
             Tuple of (valid_accounts, total_scanned)
         """
         logger.info("Starting AWS Account ID enumeration")
-        results_file = loadbalancer.threader(
+        valid_accounts = loadbalancer.threader(
             loadbalancer.getter(thread=threads, wordlist=wordlist_path), session=self.session
         )
-
-        # Load results
-        valid_accounts = []
-        if results_file and os.path.exists(results_file):
-            with open(results_file) as f:
-                valid_accounts = [line.strip() for line in f if line.strip()]
-
         total_scanned = self._count_wordlist_items(wordlist_path)
         return valid_accounts, total_scanned
 
@@ -82,16 +79,9 @@ class EnumerationHandler:
                 f.write(f"{arn}\n")
 
         try:
-            results_file = loadbalancer.threader(
+            valid_roles = loadbalancer.threader(
                 loadbalancer.getter(thread=threads, wordlist=temp_wordlist), session=self.session
             )
-
-            # Load results
-            valid_roles = []
-            if results_file and os.path.exists(results_file):
-                with open(results_file) as f:
-                    valid_roles = [line.strip() for line in f if line.strip()]
-
             return valid_roles, len(role_names)
         finally:
             # Cleanup temp file
@@ -125,16 +115,9 @@ class EnumerationHandler:
                 f.write(f"{arn}\n")
 
         try:
-            results_file = loadbalancer.threader(
+            valid_users = loadbalancer.threader(
                 loadbalancer.getter(thread=threads, wordlist=temp_wordlist), session=self.session
             )
-
-            # Load results
-            valid_users = []
-            if results_file and os.path.exists(results_file):
-                with open(results_file) as f:
-                    valid_users = [line.strip() for line in f if line.strip()]
-
             return valid_users, len(user_names)
         finally:
             # Cleanup temp file
@@ -248,13 +231,17 @@ class EnumerationHandler:
                 valid_emails.append(email)
 
             if throttling:
+                # Abort rather than emit false positives. Propagate past the
+                # broad except so the scan fails loudly instead of swallowing it.
                 logger.error("O365 is responding with false positives. Retry the scan in 1 minute.")
-                raise Exception("O365 throttling detected")
+                raise ThrottlingError("O365 throttling detected")
 
             if timeout:
                 time.sleep(int(timeout))
 
             return valid_emails, 1
+        except ThrottlingError:
+            raise
         except Exception as e:
             logger.error(f"Error checking Microsoft 365 user {email}: {e}")
             return [], 1

--- a/quiet_riot/core/scanner.py
+++ b/quiet_riot/core/scanner.py
@@ -77,7 +77,8 @@ class Scanner:
         # Add to config
         self.cfg.add_scan_object(ecr_public_repo)
         self.cfg.add_scan_object(ecr_private_repo)
-        sns_topic_arn = f"arn:aws:sns:us-east-1:{self.cfg.account_no}:{sns_topic}"
+        region = self.session.region_name or "us-east-1"
+        sns_topic_arn = f"arn:aws:sns:{region}:{self.cfg.account_no}:{sns_topic}"
         self.cfg.add_scan_object(sns_topic_arn)
         self.cfg.add_scan_object(s3_bucket)
         self.cfg.add_scan_object(canonical_id)
@@ -174,13 +175,16 @@ class Scanner:
 
         logger.info(f"Starting scan {scan_id} of type {scan_config.scan_type}")
 
-        # Setup resources (only for AWS scans that need them)
+        # Setup resources (only for AWS scans that need them). AWS_ROOT_USER_EMAIL
+        # uses the S3-ACL technique, which reads the created bucket + canonical id
+        # from scan_objects[3]/[4] — so it MUST provision resources too.
         needs_resources = scan_config.scan_type in [
             ScanType.AWS_ACCOUNT_IDS,
             ScanType.AWS_SERVICES_FOOTPRINTING,
             ScanType.AWS_IAM_PRINCIPALS,
             ScanType.AWS_IAM_ROLES,
             ScanType.AWS_IAM_USERS,
+            ScanType.AWS_ROOT_USER_EMAIL,
         ]
 
         try:

--- a/tests/live/test_live_aws.py
+++ b/tests/live/test_live_aws.py
@@ -11,6 +11,8 @@ real AWS (moto cannot mock ECR-Public).
 """
 
 import contextlib
+import json
+import time
 import uuid
 
 import pytest
@@ -105,6 +107,59 @@ def test_live_s3acl_invalid_email_returns_fail(live_session):
 # Repeats the known-valid id enough times that the random load-balancer routes
 # it through the (formerly broken) ECR-Public path with overwhelming probability.
 # --------------------------------------------------------------------------- #
+def _retry_pass(checker, principal, session, tries=6, delay=2):
+    """Retry a positive check briefly to absorb IAM eventual consistency."""
+    result = "Fail"
+    for _ in range(tries):
+        result = checker(principal, session)
+        if result == "Pass":
+            return result
+        time.sleep(delay)
+    return result
+
+
+def test_live_detects_real_vs_fake_role_and_user(live_session):
+    """The core technique must distinguish a REAL role/user ARN from a FAKE one,
+    not just account ids. Creates real IAM principals and verifies Pass/Fail."""
+    account = live_session._qr_account_id
+    iam = live_session.client("iam")
+    s = _suffix()
+    role_name = f"quiet-riot-test-role-{s}"
+    user_name = f"quiet-riot-test-user-{s}"
+    trust = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"}
+            ],
+        }
+    )
+    iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust)
+    iam.create_user(UserName=user_name)
+
+    ecrpub = live_session.client("ecr-public", region_name="us-east-1")
+    repo = f"quiet-riot-public-repo-test-{s}"
+    ecrpub.create_repository(repositoryName=repo)
+    configure_scan(account_no=account, ecr_pub=repo)
+
+    real_role = f"arn:aws:iam::{account}:role/{role_name}"
+    real_user = f"arn:aws:iam::{account}:user/{user_name}"
+    fake_role = f"arn:aws:iam::{account}:role/quiet-riot-nope-{uuid.uuid4().hex[:8]}"
+    fake_user = f"arn:aws:iam::{account}:user/quiet-riot-nope-{uuid.uuid4().hex[:8]}"
+    try:
+        assert _retry_pass(ecrpubenum.ecr_princ_checker, real_role, live_session) == "Pass"
+        assert _retry_pass(ecrpubenum.ecr_princ_checker, real_user, live_session) == "Pass"
+        assert ecrpubenum.ecr_princ_checker(fake_role, live_session) == "Fail"
+        assert ecrpubenum.ecr_princ_checker(fake_user, live_session) == "Fail"
+    finally:
+        with contextlib.suppress(Exception):
+            ecrpub.delete_repository(repositoryName=repo, force=True)
+        with contextlib.suppress(Exception):
+            iam.delete_role(RoleName=role_name)
+        with contextlib.suppress(Exception):
+            iam.delete_user(UserName=user_name)
+
+
 def test_live_full_account_id_scan(live_session, tmp_path):
     from quiet_riot.core.scanner import Scanner
 

--- a/tests/live/test_live_saas.py
+++ b/tests/live/test_live_saas.py
@@ -43,8 +43,10 @@ def test_live_m365_user_invalid_does_not_crash(handler):
     assert isinstance(valid, list)
 
 
-def test_live_google_workspace_runs(handler):
-    """The Google gxlu probe should execute and return a list without raising."""
+def test_live_google_workspace_gxlu_is_deprecated(handler):
+    """Google disabled the gxlu oracle (verified: HTTP 204, no cookies, for a known
+    real Workspace account AND a fake one), so this scan can no longer detect
+    anyone. Assert the known-dead state instead of pretending it works."""
     valid, checked = handler.scan_google_workspace_user("not-a-real-user@example.invalid")
     assert checked == 1
-    assert isinstance(valid, list)
+    assert valid == []

--- a/tests/live/test_live_saas.py
+++ b/tests/live/test_live_saas.py
@@ -31,8 +31,14 @@ def test_live_m365_domain_nonexistent(handler):
 
 
 def test_live_m365_user_invalid_does_not_crash(handler):
-    """An obviously-invalid user must return cleanly (no exception bubbling)."""
-    valid, checked = handler.scan_microsoft_365_user("not-a-real-user@example.invalid")
+    """An obviously-invalid user returns cleanly, OR (when O365 is rate-limiting us)
+    raises ThrottlingError — which is the correct, non-silent throttle behavior."""
+    from quiet_riot.core.enumeration_handlers import ThrottlingError
+
+    try:
+        valid, checked = handler.scan_microsoft_365_user("not-a-real-user@example.invalid")
+    except ThrottlingError:
+        pytest.skip("O365 is throttling right now; throttling correctly raised instead of being swallowed")
     assert checked == 1
     assert isinstance(valid, list)
 

--- a/tests/live/test_live_saas.py
+++ b/tests/live/test_live_saas.py
@@ -4,11 +4,20 @@ These hit external identity endpoints (no AWS required) and are gated behind
 ``--run-live`` / ``QR_LIVE=1``. They validate the non-AWS enumeration paths.
 """
 
+import os
+import time
+
 import pytest
 
-from quiet_riot.core.enumeration_handlers import EnumerationHandler
+from quiet_riot.core.enumeration_handlers import EnumerationHandler, ThrottlingError
 
 pytestmark = pytest.mark.live
+
+# Known-real accounts/domains for CI canaries, injected via GitHub secrets so the
+# values are never committed and are masked in CI logs. Tests skip if unset.
+M365_REAL_EMAIL = os.environ.get("QR_TEST_M365_EMAIL")
+M365_REAL_DOMAIN = os.environ.get("QR_TEST_M365_DOMAIN")
+GOOGLE_REAL_EMAIL = os.environ.get("QR_TEST_GOOGLE_EMAIL")
 
 
 @pytest.fixture
@@ -50,3 +59,40 @@ def test_live_google_workspace_gxlu_is_deprecated(handler):
     valid, checked = handler.scan_google_workspace_user("not-a-real-user@example.invalid")
     assert checked == 1
     assert valid == []
+
+
+# --------------------------------------------------------------------------- #
+# Real-account canaries (CI only — driven by GitHub secrets). These continuously
+# verify detection against a known-real account so a silent regression (or, for
+# Google, a revival) is caught.
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not M365_REAL_DOMAIN, reason="QR_TEST_M365_DOMAIN not set")
+def test_live_m365_real_domain_detected(handler):
+    valid, checked = handler.scan_microsoft_365_domain(M365_REAL_DOMAIN)
+    assert checked == 1
+    assert valid == [M365_REAL_DOMAIN], "known-real M365 domain should be detected"
+
+
+@pytest.mark.skipif(not M365_REAL_EMAIL, reason="QR_TEST_M365_EMAIL not set")
+def test_live_m365_real_user_detected_as_valid(handler):
+    """A known-real M365 user must resolve as VALID (skips if O365 throttles)."""
+    for _ in range(4):
+        try:
+            valid, checked = handler.scan_microsoft_365_user(M365_REAL_EMAIL)
+        except ThrottlingError:
+            time.sleep(15)
+            continue
+        assert checked == 1
+        assert valid == [M365_REAL_EMAIL], "known-real M365 user should resolve as valid"
+        return
+    pytest.skip("O365 throttled every attempt")
+
+
+@pytest.mark.skipif(not GOOGLE_REAL_EMAIL, reason="QR_TEST_GOOGLE_EMAIL not set")
+def test_live_google_real_user_canary_confirms_gxlu_dead(handler):
+    """Canary: gxlu is dead, so even a known-real Workspace account returns [].
+    If this FAILS (returns the user), Google re-enabled gxlu and scan 7 can be
+    revived — a wanted signal, not a flaky test."""
+    valid, checked = handler.scan_google_workspace_user(GOOGLE_REAL_EMAIL)
+    assert checked == 1
+    assert valid == [], "gxlu still dead; failure here means Google re-enabled it (revive scan 7)"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -4,6 +4,8 @@ Uses Starlette's TestClient (no real AWS; the global scanner is mocked).
 """
 
 from datetime import datetime
+import threading
+import time
 from unittest import mock
 
 from fastapi.testclient import TestClient
@@ -58,24 +60,53 @@ def test_auth_disabled_by_default(client, monkeypatch):
     assert client.get("/api/scans").status_code == 200
 
 
-def test_start_scan_returns_202_running_immediately(client, monkeypatch):
+def test_start_scan_is_nonblocking_and_reaches_completed(client, monkeypatch):
+    """Prove the scan runs off the event loop: POST returns 202 *while the scan is
+    still blocked*, /health stays responsive, and the job later reaches completed."""
     monkeypatch.setattr(server, "API_TOKEN", None)
     monkeypatch.setattr(server, "credentials_required", False)
-    fake = mock.Mock()
-    fake.run_scan.return_value = ScanResult(
-        scan_id="internal",
-        scan_type=ScanType.MICROSOFT_365_DOMAINS,
-        status="completed",
-        valid_principals=[],
-        total_scanned=1,
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-    )
-    fake.resource_mgr.resources_created = False
-    monkeypatch.setattr(server, "scanner", fake)
+    monkeypatch.setattr(server, "scanner", mock.Mock())  # provides effective_session
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_run(scan_config, cleanup=False):
+        started.set()
+        if not release.wait(timeout=10):
+            raise AssertionError("scan was never released")
+        return ScanResult(
+            scan_id="internal",
+            scan_type=ScanType.MICROSOFT_365_DOMAINS,
+            status="completed",
+            valid_principals=[],
+            total_scanned=1,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+
+    fake_scanner = mock.Mock()
+    fake_scanner.run_scan.side_effect = blocking_run
+    fake_scanner.resource_mgr.resources_created = False
+    # Scanner is constructed inside _execute; patch the class to our fake.
+    monkeypatch.setattr(server, "Scanner", lambda session: fake_scanner)
 
     r = client.post("/api/scans", json={"scan_type": 2, "domain_name": "example.com"})
     assert r.status_code == 202
-    body = r.json()
-    assert body["status"] == "running"
-    assert "scan_id" in body
+    job = r.json()["scan_id"]
+    assert r.json()["status"] == "running"
+
+    # The scan actually began in a worker thread...
+    assert started.wait(timeout=5), "background scan never started"
+    # ...and the server is NOT blocked while it runs.
+    assert client.get("/health").status_code == 200
+    assert client.get(f"/api/scans/{job}").json()["status"] == "running"
+
+    # Let the scan finish and confirm the lifecycle write-back to "completed".
+    release.set()
+    final = "running"
+    for _ in range(50):
+        final = client.get(f"/api/scans/{job}").json()["status"]
+        if final == "completed":
+            break
+        time.sleep(0.1)
+    assert final == "completed"

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -36,12 +36,13 @@ def test_distributed_backend_is_clear_about_being_unimplemented():
         DistributedBackend().run("wl.txt", session=None, threads=1)
 
 
-def test_local_backend_delegates_and_reads_results(monkeypatch, tmp_path):
-    results = tmp_path / "valid.txt"
-    results.write_text("123456789012\n210987654321\n")
-
+def test_local_backend_delegates_to_threader(monkeypatch):
     monkeypatch.setattr(backends.loadbalancer, "getter", lambda thread, wordlist: [["a"]])
-    monkeypatch.setattr(backends.loadbalancer, "threader", lambda words, session: str(results))
+    monkeypatch.setattr(
+        backends.loadbalancer,
+        "threader",
+        lambda words, session: ["123456789012", "210987654321"],
+    )
 
     out = LocalThreadPoolBackend().run("wl.txt", session=object(), threads=10)
     assert out == ["123456789012", "210987654321"]

--- a/tests/unit/test_saas_handlers.py
+++ b/tests/unit/test_saas_handlers.py
@@ -1,0 +1,78 @@
+"""Unit tests for the SaaS (M365 / Google Workspace) detection logic.
+
+These mock the HTTP layer so the parsing/branching is covered without network.
+The live equivalents (tests/live/test_live_saas.py) verify against real endpoints.
+"""
+
+import pytest
+
+from quiet_riot.core import enumeration_handlers
+from quiet_riot.core.enumeration_handlers import EnumerationHandler, ThrottlingError
+
+
+class FakeResponse:
+    def __init__(self, text="", status_code=200, cookies=None):
+        self.text = text
+        self.status_code = status_code
+        self.cookies = cookies if cookies is not None else []
+
+
+@pytest.fixture
+def handler():
+    return EnumerationHandler(session=None)
+
+
+# --- Microsoft 365 user ---
+def test_m365_user_valid(handler, monkeypatch):
+    monkeypatch.setattr(enumeration_handlers.requests, "post", lambda *a, **k: FakeResponse('"IfExistsResult":0,'))
+    valid, checked = handler.scan_microsoft_365_user("real@tenant.com")
+    assert valid == ["real@tenant.com"]
+    assert checked == 1
+
+
+def test_m365_user_invalid(handler, monkeypatch):
+    monkeypatch.setattr(enumeration_handlers.requests, "post", lambda *a, **k: FakeResponse('"IfExistsResult":1,'))
+    valid, _ = handler.scan_microsoft_365_user("nope@tenant.com")
+    assert valid == []
+
+
+def test_m365_user_throttling_raises(handler, monkeypatch):
+    # Throttling must propagate (ThrottlingError), not be swallowed as a negative.
+    monkeypatch.setattr(enumeration_handlers.requests, "post", lambda *a, **k: FakeResponse('"ThrottleStatus":1'))
+    with pytest.raises(ThrottlingError):
+        handler.scan_microsoft_365_user("x@tenant.com")
+
+
+# --- Microsoft 365 domain ---
+def test_m365_domain_managed(handler, monkeypatch):
+    monkeypatch.setattr(
+        enumeration_handlers.requests, "get", lambda *a, **k: FakeResponse('"NameSpaceType":"Managed",')
+    )
+    valid, _ = handler.scan_microsoft_365_domain("tenant.com")
+    assert valid == ["tenant.com"]
+
+
+def test_m365_domain_absent(handler, monkeypatch):
+    monkeypatch.setattr(
+        enumeration_handlers.requests, "get", lambda *a, **k: FakeResponse('"NameSpaceType":"Unknown",')
+    )
+    valid, _ = handler.scan_microsoft_365_domain("nope.invalid")
+    assert valid == []
+
+
+# --- Google Workspace (gxlu) ---
+def test_google_workspace_gxlu_204_returns_empty(handler, monkeypatch):
+    # The real-world state: Google returns 204 with no cookies for everyone.
+    monkeypatch.setattr(enumeration_handlers.requests, "get", lambda *a, **k: FakeResponse(status_code=204, cookies=[]))
+    valid, checked = handler.scan_google_workspace_user("anyone@workspace.com")
+    assert valid == []
+    assert checked == 1
+
+
+def test_google_workspace_legacy_success_path_still_works(handler, monkeypatch):
+    # If Google ever re-enables the single-cookie signal, the success path holds.
+    monkeypatch.setattr(
+        enumeration_handlers.requests, "get", lambda *a, **k: FakeResponse(status_code=200, cookies=["one"])
+    )
+    valid, _ = handler.scan_google_workspace_user("real@workspace.com")
+    assert valid == ["real@workspace.com"]

--- a/tests/unit/test_scanner_routing.py
+++ b/tests/unit/test_scanner_routing.py
@@ -78,3 +78,17 @@ def test_cleanup_called_for_resource_scans(scanner, wordlist):
     cfg = ScanConfig(scan_type=ScanType.AWS_ACCOUNT_IDS, wordlist_path=wordlist)
     scanner.run_scan(cfg, cleanup=True)
     scanner.resource_mgr.cleanup_all.assert_called_once()
+
+
+def test_root_email_scan_provisions_resources(scanner):
+    """Regression: AWS_ROOT_USER_EMAIL must provision resources.
+
+    It uses the S3-ACL technique, which reads the created bucket/canonical id from
+    scan_objects[3]/[4]. It was missing from needs_resources, so _setup_resources
+    never ran and the scan IndexError'd before any AWS call.
+    """
+    scanner.enumeration_handler.scan_aws_root_email.return_value = ([], 1)
+    cfg = ScanConfig(scan_type=ScanType.AWS_ROOT_USER_EMAIL, single_email="nope@example.invalid")
+    result = scanner.run_scan(cfg, cleanup=False)
+    assert result.status == "completed", result.error
+    scanner._setup_resources.assert_called_once()


### PR DESCRIPTION
Follow-up driven by a sharp question — *does the error-message technique actually detect roles/users/services correctly, or just account ids?* I ran it live against our own account and then an adversarial multi-agent review over the merged overhaul. **Answer: detection is correct at every granularity** (real role/user/account ARN → Pass, fake → Fail, across ECR-Public / SNS / ECR-Private), but the review surfaced real bugs — fixed here.

## Detection / scan correctness
- **Scan 4 (AWS Root User Email) was broken end-to-end** — missing from the scanner's `needs_resources`, so it never provisioned the S3 bucket and `IndexError`'d on `scan_objects[3]` before any AWS call. The old live test masked it by hand-injecting config. Fixed + a unit regression guard that scan-4 actually provisions.
- **Shared results file** — `loadbalancer` used a module-level timestamp and `a+` append, so results bled across scans and **double-counted IAM-principal hits** (roles + users scans appended to one file). Now returns the validated list in-memory + a unique per-scan file.
- **SNS ARN hardcoded `us-east-1`** while the topic is created in the session region → SNS enumeration + cleanup now use the real region.
- **M365 throttling was swallowed** by its own `except` (scan kept hammering, emitting the false positives the log warns about). Now raises `ThrottlingError` and aborts.

## API safety
- `cleanup_infrastructure` deletes only the **exact tracked** resources, not a substring sweep of every `quiet-riot-*` resource (which destroyed concurrent scans' infra); paginated S3 empty; removes the leftover ECR registry-policy grant.
- Scans are **serialized** and the `Scanner` is built inside the worker thread, so concurrent API scans can't corrupt the process-global `Config` singleton.

## Proof
- **LIVE**: `test_live_detects_real_vs_fake_role_and_user` creates a real IAM role + user and asserts real ARN → Pass / fake ARN → Fail through the enumerators (passed against real AWS; no leaks).
- **API**: the 202 test now blocks the mocked scan and proves the POST returns while it's still running, `/health` stays responsive, and the job reaches `completed`.
- 73 unit + 9 live (1 skipped on O365 throttle) green; ruff/mypy clean.

Documented follow-ups (edge cases for dedicated-account use): save/restore a pre-existing ECR registry policy; track each resource as created to avoid mid-setup orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)